### PR TITLE
Upgrade "illuminate/support" and "illuminate/routing" dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "~5.1",
-        "illuminate/routing": "~5.1"
+        "illuminate/support": "~5.1|^6.0|^7.0",
+        "illuminate/routing": "~5.1|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*"


### PR DESCRIPTION
By upgrading Laravel dependencies, this package can be used in Laravel 6x and 7x projects